### PR TITLE
Implement http patch method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.idea/
+*.iml
+*.iws
+target/
+pom.xml.releaseBackup
+release.properties
+snapshots
+coverage-error.log

--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
     <dependency>
       <groupId>net.code-story</groupId>
       <artifactId>http</artifactId>
-      <version>2.102</version>
+      <version>2.105</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/net/codestory/rest/FluentRestTest.java
+++ b/src/main/java/net/codestory/rest/FluentRestTest.java
@@ -69,4 +69,18 @@ public interface FluentRestTest {
   default RestAssert options(String path) {
     return get(path).withRequest(request -> request.method("OPTIONS", null));
   }
+
+  // PATCH
+  default RestAssert patch(String path) {
+    return get(path).withRequest(request -> request.patch(PostBody.empty()));
+  }
+
+  default RestAssert patch(String path, String body) {
+    return get(path).withRequest(request -> request.patch(PostBody.json(body)));
+  }
+
+  default RestAssert patch(String path, String firstParameterName, Object firstParameterValue, Object... parameterNameValuePairs) {
+    return get(path).withRequest(request -> request.patch(PostBody.form(firstParameterName, firstParameterValue, parameterNameValuePairs)));
+  }
+
 }

--- a/src/test/java/net/codestory/rest/PatchTest.java
+++ b/src/test/java/net/codestory/rest/PatchTest.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2013-2015 all@code-story.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package net.codestory.rest;
+
+import net.codestory.http.payload.Payload;
+import org.junit.Test;
+
+public class PatchTest extends AbstractTest {
+  @Test
+  public void patch_empty() {
+    configure(routes -> routes
+        .patch("/", () -> Payload.created())
+    );
+
+    patch("/").should()
+      .respond(201)
+      .contain("");
+  }
+
+  @Test
+  public void patch_body() {
+    configure(routes -> routes
+        .patch("/", context -> new Payload("text/plain", context.request().content(), 201))
+    );
+
+    patch("/", "<body>").should().respond(201).contain("<body>");
+  }
+
+  @Test
+  public void patch_form() {
+    configure(routes -> routes
+        .patch("/", context -> new Payload("text/plain", context.get("key1") + "&" + context.get("key2"), 201))
+    );
+
+    patch("/", "key1", "1st", "key2", "2nd").should().respond(201).contain("1st&2nd");
+  }
+}


### PR DESCRIPTION
needs fluent-http with PATCH support
but fluent-http depends on fluent-rest-test to enable PATCH support
